### PR TITLE
Reinstate dnspython

### DIFF
--- a/install-ansible.sh
+++ b/install-ansible.sh
@@ -186,6 +186,13 @@ if ! pip install shade; then
   exit 1
 fi
 
+# Install dnspython so we can do opendns lookups
+# this lets us create better default security group rules
+if ! pip install dnspython; then
+  echo "Could not install dnspython"
+  exit 1
+fi
+
 echo
 echo "Ansible installed successfully!"
 echo


### PR DESCRIPTION
Reinstate dnspython as removing pip install dnspython breaks a lot of playbooks in this repo that are using it to lookup the external ip so they can replace 0.0.0.0/0 as the ingress cidr address on security group rules.