### PR TITLE
explicitly install python-openstackclient and openstacksdk

### DIFF
--- a/install-ansible.sh
+++ b/install-ansible.sh
@@ -181,7 +181,7 @@ else
 fi
 
 # Install the shade library and the OpenStack client libraries.
-if ! pip install shade; then
+if ! pip install shade python-openstackclient openstacksdk; then
   echo "Could not install the OpenStack client tools and shade"
   exit 1
 fi
@@ -198,7 +198,7 @@ echo "Ansible installed successfully!"
 echo
 echo "The following versions are installed in $PWD/$ANSIBLE_VENV:"
 echo
-"$PWD/$ANSIBLE_VENV/bin/pip" freeze | egrep 'ansible|shade|openstackclient'
+"$PWD/$ANSIBLE_VENV/bin/pip" freeze | egrep 'ansible|shade|openstackclient|openstacksdk'
 echo
 echo "To activate run the following command:"
 echo


### PR DESCRIPTION
Shade is currently at version 1.25.0, it was released on 2017-11-29.
Shade includes python-ironicclient in its requirements.txt

In shade versions prior to 1.25.0 openstacksdk and
python-openstackclient have been installed as transitive depends via
python-ironicclient. Since 1.25.0 this is no longer the case.

The upshot is that prior to the release of 1.25.0 on 2017-11-29 people
running install-ansible.sh would have been getting openstacksdk and
python-openstackclient. Some people may have been relying on this fact,
the next time they install they may experience unfamiliar behaviour due
to this change.

I propose that we explicitly install openstacksdk and
python-openstackclient in install-ansible.sh
