### PR TITLE
Creating host fails when ansible attempts to ssh into machine

### DIFF
--- a/example-playbooks/docker-swarm-mode/create-swarm-hosts.yaml
+++ b/example-playbooks/docker-swarm-mode/create-swarm-hosts.yaml
@@ -197,6 +197,8 @@
   become: yes
   become_method: sudo
   gather_facts: False
+  vars:
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 
   pre_tasks:
     - name: Install python-minimal for Ansible


### PR DESCRIPTION
Privilege escalation query times out:
 http://paste.wgtn.cat-it.co.nz/1c70c2#O/iq8YF3epghn5+vBJ8JOg

It only seems to works when `ansible_ssh_common_args: '-o StrictHostKeyChecking=no'` is defined in the play.